### PR TITLE
Fix lava lash damage bonus from flametongue weapon.

### DIFF
--- a/src/server/game/Spells/SpellMgr.cpp
+++ b/src/server/game/Spells/SpellMgr.cpp
@@ -3811,6 +3811,9 @@ void SpellMgr::LoadSpellInfoCorrections()
             case 49575: // Death Grip
                 spellInfo->Effects[EFFECT_0].MiscValue = 20;
                 break;
+            case 60103: // Lava Lash
+                spellInfo->Effects[EFFECT_1].TargetA = SpellImplicitTargetInfo(TARGET_UNIT_TARGET_ENEMY);
+                break;
             // END OF TRUEWOW HACKS
             default:
                 break;


### PR DESCRIPTION
http://www.truewow.org/bugs/view.php?id=64

Lava Lash 25% damage bonus when flametongue is used on offhand (and another 10% bonus with glyph).
Require target on effect 1 to work with spell_sha_lava_lash script.