### PR TITLE
Feral spirit petautocast

### DIFF
--- a/src/server/game/Handlers/PetHandler.cpp
+++ b/src/server/game/Handlers/PetHandler.cpp
@@ -737,7 +737,9 @@ void WorldSession::HandlePetSpellAutocastOpcode(WorldPacket& recvPacket)
     if (pet->IsPet())
         ((Pet*)pet)->ToggleAutocast(spellInfo, state != 0);
     else
-        pet->GetCharmInfo()->ToggleCreatureAutocast(spellInfo, state != 0);
+        for (Unit::ControlList::iterator itr = GetPlayer()->m_Controlled.begin(); itr != GetPlayer()->m_Controlled.end(); ++itr)
+            if ((*itr)->GetEntry() == pet->GetEntry())
+                (*itr)->GetCharmInfo()->ToggleCreatureAutocast(spellInfo, state != 0);
 
     charmInfo->SetSpellAutocast(spellInfo, state != 0);
 }


### PR DESCRIPTION
Fix macro for feral spirit:
/petautocastoff
/petautocaston
/petautocasttoggle
Need to loop over controlled units since there are two wolves. Without that, only one of them get the action removed from autocast and it will still launch the action.